### PR TITLE
migrating ec2 instance to t2.nano from t2.micro

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -7,5 +7,5 @@ variable "aws_region" {
 variable "instance_type" {
   description = "EC2 instance type"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.nano"
 }


### PR DESCRIPTION
We are downgrading our EC2 instance from `t2.micro` to `t2.nano` to save costs. 