### PR TITLE
add membership tier to the api return

### DIFF
--- a/internal/database/gamer_activity_repository.go
+++ b/internal/database/gamer_activity_repository.go
@@ -245,13 +245,14 @@ func toGamerActivitiesFromActiveSessions(rows []sqlc.GetActiveSessionsRow) []mod
 	activities := make([]models.GamerActivity, len(rows))
 	for i, row := range rows {
 		activities[i] = models.GamerActivity{
-			ID:            row.ID.String(),
-			StudentNumber: row.StudentNumber,
-			PCNumber:      int(row.PcNumber.Int32),
-			Game:          row.Game.String,
-			StartedAt:     row.StartedAt.Time,
-			FirstName:     &row.FirstName,
-			LastName:      &row.LastName,
+			ID:             row.ID.String(),
+			StudentNumber:  row.StudentNumber,
+			PCNumber:       int(row.PcNumber.Int32),
+			Game:           row.Game.String,
+			MembershipTier: int(row.MembershipTier),
+			StartedAt:      row.StartedAt.Time,
+			FirstName:      &row.FirstName,
+			LastName:       &row.LastName,
 		}
 		if row.EndedAt.Valid {
 			activities[i].EndedAt = &row.EndedAt.Time

--- a/internal/database/queries/gamer_activity.sql
+++ b/internal/database/queries/gamer_activity.sql
@@ -48,7 +48,7 @@ RETURNING id, student_number, pc_number, game, started_at, ended_at, exec_name;
 
 -- name: GetActiveSessions :many
 SELECT ga.id, ga.student_number, ga.pc_number, ga.game, ga.started_at, ga.ended_at, ga.exec_name,
-       gp.first_name, gp.last_name
+       gp.first_name, gp.last_name, gp.membership_tier
 FROM gamer_activity ga
 JOIN gamer_profile gp ON ga.student_number = gp.student_number
 WHERE ga.ended_at IS NULL;

--- a/internal/database/sqlc/gamer_activity.sql.go
+++ b/internal/database/sqlc/gamer_activity.sql.go
@@ -59,22 +59,23 @@ func (q *Queries) CreateGamerActivity(ctx context.Context, arg CreateGamerActivi
 
 const getActiveSessions = `-- name: GetActiveSessions :many
 SELECT ga.id, ga.student_number, ga.pc_number, ga.game, ga.started_at, ga.ended_at, ga.exec_name,
-       gp.first_name, gp.last_name
+       gp.first_name, gp.last_name, gp.membership_tier
 FROM gamer_activity ga
 JOIN gamer_profile gp ON ga.student_number = gp.student_number
 WHERE ga.ended_at IS NULL
 `
 
 type GetActiveSessionsRow struct {
-	ID            uuid.UUID
-	StudentNumber string
-	PcNumber      sql.NullInt32
-	Game          sql.NullString
-	StartedAt     sql.NullTime
-	EndedAt       sql.NullTime
-	ExecName      sql.NullString
-	FirstName     string
-	LastName      string
+	ID             uuid.UUID
+	StudentNumber  string
+	PcNumber       sql.NullInt32
+	Game           sql.NullString
+	StartedAt      sql.NullTime
+	EndedAt        sql.NullTime
+	ExecName       sql.NullString
+	FirstName      string
+	LastName       string
+	MembershipTier int32
 }
 
 func (q *Queries) GetActiveSessions(ctx context.Context) ([]GetActiveSessionsRow, error) {
@@ -96,6 +97,7 @@ func (q *Queries) GetActiveSessions(ctx context.Context) ([]GetActiveSessionsRow
 			&i.ExecName,
 			&i.FirstName,
 			&i.LastName,
+			&i.MembershipTier,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/models/gamer.go
+++ b/internal/models/gamer.go
@@ -15,15 +15,16 @@ type GamerProfile struct {
 }
 
 type GamerActivity struct {
-	ID            string     `json:"id"`
-	StudentNumber string     `json:"student_number"`
-	PCNumber      int        `json:"pc_number"`
-	Game          string     `json:"game"`
-	StartedAt     time.Time  `json:"started_at"`
-	EndedAt       *time.Time `json:"ended_at,omitempty"`
-	ExecName      *string    `json:"exec_name,omitempty"`
-	FirstName     *string    `json:"first_name,omitempty"`
-	LastName      *string    `json:"last_name,omitempty"`
+	ID             string     `json:"id"`
+	StudentNumber  string     `json:"student_number"`
+	PCNumber       int        `json:"pc_number"`
+	Game           string     `json:"game"`
+	MembershipTier int        `json:"membership_tier"`
+	StartedAt      time.Time  `json:"started_at"`
+	EndedAt        *time.Time `json:"ended_at,omitempty"`
+	ExecName       *string    `json:"exec_name,omitempty"`
+	FirstName      *string    `json:"first_name,omitempty"`
+	LastName       *string    `json:"last_name,omitempty"`
 }
 
 type CreateGamerProfileRequest struct {


### PR DESCRIPTION
## Description
The old API returned the membership tier for each active PC because it was needed for the time remaining calculations. This PR adds that field back. 